### PR TITLE
modprobe.d: Set RAID0 default layout

### DIFF
--- a/modprobe.d/raid0.conf
+++ b/modprobe.d/raid0.conf
@@ -1,0 +1,5 @@
+# Only care about the alternate RAID0 layout from post-Linux-3.14 setups,
+# will cause data corruption with older ones. No detection is possible in
+# that case, see:
+# https://github.com/torvalds/linux/commit/c84a1372df929033cb1a0441fb57bd3932f39ac9
+options raid0 default_layout=2


### PR DESCRIPTION
The RAID0 layout changed from pre- to post-Linux-3.14
without any versioning information, which was only added
recently in mdadm. Therefore, when a RAID0 setup lacks the
versioning information we need to define what the default is,
or otherwise the kernel refuses to operate it.
Chose the alternate layout because we care about setups that
are created with post-3.14 kernels which are in use for the
last five years already.

**Note:** Requires https://github.com/flatcar-linux/coreos-overlay/pull/147 to be updated when the commit ID here changes