### PR TITLE
Ensure that the /etc/pam.d directory exists.

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -4,6 +4,7 @@ L   /etc/issue                        -   -   -   -   ../usr/share/baselayout/is
 L   /etc/motd                         -   -   -   -   ../run/flatcar/motd
 L   /etc/nsswitch.conf                -   -   -   -   ../usr/share/baselayout/nsswitch.conf
 L   /etc/lsb-release                  -   -   -   -   ../usr/share/flatcar/lsb-release
+d   /etc/pam.d                        0755    root    root    -   -
 L   /etc/profile                      -   -   -   -   ../usr/share/baselayout/profile
 d   /etc/profile.d                    0755    root    root    -   -
 L   /etc/profile.d/flatcar-profile.sh  -   -   -   -   ../../usr/share/baselayout/flatcar-profile.sh


### PR DESCRIPTION
This directory is necessary for normal functioning of the system.
Apparently systemd was creating it before, but no longer does.

Fixes: flatcar-linux/Flatcar#75

(See the issue for a lot more description of what's going on)
