### PR TITLE
Run flatcar-tmpfiles only once, sys-fs/lvm2: Run lvm2-activation(-early).service only once

### DIFF
--- a/scripts/flatcar-tmpfiles.service
+++ b/scripts/flatcar-tmpfiles.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=Create missing system files
 DefaultDependencies=no
+Wants=sysroot.mount sysroot-usr.mount
+After=sysroot.mount sysroot-usr.mount
 Before=sysinit.target systemd-sysusers.service
 ConditionPathIsReadWrite=/etc
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/sbin/flatcar-tmpfiles


### PR DESCRIPTION
The flatcar-tmpfiles and clean-ca-certificates services were run
    many times and finally failed to run because they were spawned too
    often during the allowed time period.
    Mark them as active after they ran once. Also ensure that when they
    run all mounts are ready.

# How to use



# Testing done

The restart errors are gone. Two test errors are still present and it's not clear if they are unrelated or were introduced by the tmpfile service change.