### PR TITLE
scripts: Allow overriding the base

### DIFF
--- a/scripts/flatcar-tmpfiles
+++ b/scripts/flatcar-tmpfiles
@@ -6,11 +6,13 @@
 
 # Inherit root from environment or command line
 ROOT="${1:-$ROOT}"
-BASE="${ROOT}/usr/share/baselayout"
+BASE="${2:-${ROOT}/usr/share/baselayout}"
 
 # Users/Groups to copy so they can be modified
 COPY_USERS="root|core"
-COPY_GROUPS="docker|sudo|wheel"
+COPY_GROUPS="root|core|docker|sudo|wheel"
+
+mkdir -p "${ROOT}/etc"
 
 # readable files
 umask 022


### PR DESCRIPTION
This PR is a part of systemd update.

When the second parameter is not provided, the script works as it used
to.

The reason for the change is to be able to run the script before
anything is provisioned in the new root filesystem. This will populate
the /etc/passwd and /etc/group files therein, so systemd-tmpfiles can
resolve the user and group information used in tmpfiles. This is a
change in systemd made in 246, as it only resolves the user and group
information from databases inside the overridden root filesystem (with
the --root flag).

This also extends the groups with the root and core groups to be
copied over, because these groups are needed by systemd-tmpfiles too.

Test build is here: http://localhost:9091/job/os/job/manifest/1138/