### PR TITLE
tmpfiles: Ensure that /etc/coreos to flatcar symlink exists

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -12,3 +12,5 @@ L   /etc/sudo.conf                    -   -   -   -   ../usr/share/baselayout/su
 d   /etc/vim                          -   -   -   -   -
 L   /etc/vim/vimrc                    -   -   -   -   ../../usr/share/vim/vimrc
 d   /etc/sudoers.d                    0750    root    root    -   -
+d   /etc/flatcar                      -   -   -   -   -
+L   /etc/coreos                       -   -   -   -   ./flatcar


### PR DESCRIPTION
The entries from the update or locksmith directive of a Container Linux
Config currently use the /etc/coreos/ folder for Ignition files:
  printf "locksmith:\n  reboot_strategy: off" | ct
results in:
  {"ignition":{"config":{},"security":{"tls":{}},"timeouts":{},
  "version":"2.3.0"},"networkd":{},"passwd":{},"storage":
  {"files":[{"filesystem":"root", "path":"/etc/coreos/update.conf",
  "contents":{"source":"data:,%0AREBOOT_STRATEGY%3D%22off%22",
  "verification":{}},"mode":420}]},"systemd":{}}
With the pre-built rootfs this works because /etc/coreos is a symlink
to /etc/flatcar. However, with a fresh rootfs created by Ignition this
results in a /etc/coreos folder created by Ignition because there is no
symlink and the resulting files are ignored since only /etc/flatcar/ is
considered by update-engine and locksmith.
Set up the symlink and the target folder through a tmpfile directive to
ensure that it is there when Ignition runs even when with a new rootfs.

Fixes https://github.com/flatcar-linux/Flatcar/issues/190


# How to use

Goes together with https://github.com/flatcar-linux/init/pull/28

Using an Ignition config like 
```
{
  "ignition": {
    "version": "2.2.0"
  },
  "storage": {
    "filesystems": [
      {
        "mount": {
          "device": "/dev/disk/by-partlabel/ROOT",
          "format": "ext4",
          "create": {
            "force": true,
            "options": [
              "-L",
              "ROOT",
              "-U",
              "9aa5237a-ab6b-458b-a7e8-f25e2baef1a3"
            ]
          }
        }
      }
    ],
    "files": [
      {
        "filesystem": "root",
        "path": "/etc/coreos/update.conf",
        "contents": {
          "source": "data:,%0AREBOOT_STRATEGY%3D%22off%22",
          "verification": {}
        },
        "mode": 420
      }
    ]
  }
}
```

should result in `/etc/flatcar/update.conf` having `REBOOT_STRATEGY="off"`.

# Testing done

With the new image that also contains the change from https://github.com/flatcar-linux/init/pull/28 I was able to use the above Ignition config successfully, meaning that the symlink was set up and the `update.conf` file was created under the `flatcar` folder.