### PR TITLE
tmpfiles.d/baselayout.conf: Add rules for /opt and /opt/bin

### DIFF
--- a/tmpfiles.d/baselayout.conf
+++ b/tmpfiles.d/baselayout.conf
@@ -2,6 +2,8 @@ d   /boot       -       -   -   -   -
 d   /dev        -       -   -   -   -
 d   /media      -       -   -   -   -
 d   /mnt        -       -   -   -   -
+d   /opt        0755    -   -   -   -
+d   /opt/bin    0755    -   -   -   -
 d   /proc       -       -   -   -   -
 d   /root       0700    -   -   -   -
 d   /run        -       -   -   -   -


### PR DESCRIPTION
The well-known path /opt/bin is used in PATH as place for extra
binaries and /opt in general is a place for additional software.
Containerd creates /opt on runtime if it is not present but uses
restrictive permissions, causing non-root programs to fail accessing,
e.g., /opt/bin.
Add tmpfile directives for /opt and /opt/bin to ensure that they
have the correct permissions.

Fixes https://github.com/kinvolk/Flatcar/issues/279


# How to use

Boot the image, run `docker ps` for containerd to create `/opt/containerd…`, and check that `stat /opt` is 755.

# Testing done

Created a separate tmpfile directive in /etc/tmpfiles.d/ with the two lines.