### PR TITLE
baselayout/profile: Prefer /opt/bin in PATH

### DIFF
--- a/baselayout/profile
+++ b/baselayout/profile
@@ -22,7 +22,9 @@ umask 022
 
 # Set up PATH, all users get both bin and sbin to keep things simple.
 # Gentoo normally splits this up which is why the variable is called ROOTPATH
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin${ROOTPATH:+:}${ROOTPATH-}"
+# and in our case should only contain /opt/bin (see env.d/00basic which ends up in
+# /usr/share/baselayout/profile.env)
+export PATH="${ROOTPATH-}${ROOTPATH:+:}/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 unset ROOTPATH
 
 if [ -n "${BASH_VERSION-}" ] ; then


### PR DESCRIPTION
The /opt/bin location for additional binaries was at the end of PATH.
This does not allow to replace binaries in /usr when a custom version
should be used, and a bind-mount is needed.
Instead of requiring a bind-mount, give preference to binaries in
/opt/bin.

# How to use

Provision a custom Docker without Torcx and without requiring bind mounts

(here a Container Linux Config *with* a bind mount: [ignition-docker.txt](https://github.com/kinvolk/baselayout/files/5582629/ignition-docker.txt))

# Testing done

[Tests passed](http://localhost:9091/job/os/job/manifest/1537/console), using the following Container Linux Config *without* a bind mount and special paths works: [ignition-docker-new.txt](https://github.com/kinvolk/baselayout/files/5594859/ignition-docker-new.txt)
