### PR TITLE
Update nsswitch.conf to use systemd-resolved

### DIFF
--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -4,7 +4,7 @@ passwd:      files usrfiles sss systemd
 shadow:      files usrfiles sss
 group:       files usrfiles sss systemd
 
-hosts:       files usrfiles dns myhostname
+hosts:       resolve [!UNAVAIL=return] files usrfiles dns myhostname
 networks:    files usrfiles dns
 
 services:    files usrfiles

--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -4,7 +4,7 @@ passwd:      files usrfiles sss systemd
 shadow:      files usrfiles sss
 group:       files usrfiles sss systemd
 
-hosts:       files usrfiles resolve [!UNAVAIL=return] dns myhostname
+hosts:       files usrfiles resolve [!UNAVAIL=return] myhostname dns
 networks:    files usrfiles dns
 
 services:    files usrfiles

--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -4,7 +4,7 @@ passwd:      files usrfiles sss systemd
 shadow:      files usrfiles sss
 group:       files usrfiles sss systemd
 
-hosts:       resolve [!UNAVAIL=return] files usrfiles dns myhostname
+hosts:       files usrfiles resolve [!UNAVAIL=return] dns myhostname
 networks:    files usrfiles dns
 
 services:    files usrfiles


### PR DESCRIPTION
# Update nsswitch.conf to use systemd-resolved

Partly related to https://github.com/kinvolk/Flatcar/issues/285 as suggested by @pothos 
This allows nsswitch to use systemd-resolved

# How to use

Update the nsswitch.conf ;)

# Testing done

```
#/etc/systemd/resolved.conf:

[Resolve]
DNS=10.0.0.2
Domains=~example.internal
```
```
# ping web.example.internal
PING web.example.internal (10.0.154.231) 56(84) bytes of data.
...
# ping google.com
PING google.com (172.217.21.142) 56(84) bytes of data.
...
```

This test shows that systemd's split-horizon (routed-domains) is working and nsswitch is also using systemd-resolved instead of /etc/resolv.conf (the DNS referenced is NOT recursive)


__HOWEVER__

it's important to note that anything using /etc/resolv.conf will fail to use systemd-resolved until the stublistener is re-enabled and the symlink it set to `/run/systemd/resolve/stub-resolv.conf` as outlined in the linked issue. (This limitation does not impose any regression as it didnt work before at all, so this is now a half-working solution - full working is achieved by removing `/lib/systemd/resolved.conf.d/50-no-dns-listener.conf` and replacing /etc/resolv.conf)