### PR TITLE
Delete 50-no-dns-listener.conf to re-enable systemd-resolved's stub listeners

### DIFF
--- a/systemd/resolved.conf.d/50-no-dns-listener.conf
+++ b/systemd/resolved.conf.d/50-no-dns-listener.conf
@@ -1,4 +1,0 @@
-# The DNS stub listener in systemd-resolved will listen on 127.0.0.53:53, which
-# can conflict with other DNS services that listen on local interfaces.
-[Resolve]
-DNSStubListener=no


### PR DESCRIPTION
# Enable systemd-resolved's Stub Resolver

Requires https://github.com/kinvolk/coreos-overlay/pull/730

Goes in tandem with https://github.com/kinvolk/baselayout/pull/10

# How to use

Set up Split-Horizon DNS as outlined in https://github.com/kinvolk/baselayout/pull/10 

# Testing done

Same tests as https://github.com/kinvolk/baselayout/pull/10 but with `dig` instead of ping to bypass nsswitch

Related: https://github.com/kinvolk/Flatcar/issues/285
