### PR TITLE
passwd: use correct GID for tss

### DIFF
--- a/baselayout/group
+++ b/baselayout/group
@@ -43,7 +43,7 @@ systemd-bus-proxy:x:246:
 systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
-tss:x:252:tss
+tss:x:252:
 utmp:x:406:
 core:x:500:
 nogroup:x:65533:

--- a/baselayout/passwd
+++ b/baselayout/passwd
@@ -20,7 +20,7 @@ etcd:x:232:232::/dev/null:/sbin/nologin
 docker:x:233:233::/dev/null:/sbin/nologin
 tlsdate:x:234:234::/dev/null:/sbin/nologin
 polkitd:x:235:235:Policy Toolkit:/var/lib/polkit-1:/sbin/nologin
-tss:x:236:236:TCG Software Stack:/dev/null:/sbin/nologin
+tss:x:236:252:TCG Software Stack:/dev/null:/sbin/nologin
 systemd-journal-remote:x:242:242:Journal Remote:/dev/null:/sbin/nologin
 systemd-network:x:244:244:Network Management Service:/dev/null:/sbin/nologin
 systemd-resolve:x:245:245:Network Name Resolution:/dev/null:/sbin/nologin


### PR DESCRIPTION
The tss GID is not 236 but 252. Luckily the tss group explicitly put
    the user into it but still we don't want an unallocated group to be
    used. While for consistency it would be nice to choose 236 as new GID,
    this could be incompatible with any files created under /var/ or a
    similar case where the old GID is still on the filesystem. With the
    correct GID referenced, the explicit add of the user inside the group
    file is not needed anymore.

# How to use


# Testing done

