### PR TITLE
profile: filter out bullet point when parsing failed units

### DIFF
--- a/baselayout/flatcar-profile.sh
+++ b/baselayout/flatcar-profile.sh
@@ -32,7 +32,7 @@ if [[ $- == *i* ]]; then
 		)
 	fi
 
-	FAILED=$(systemctl list-units --state=failed --no-legend)
+	FAILED=$(systemctl list-units --state=failed --no-legend | tr '●' ' ')
 	if [[ ! -z "${FAILED}" ]]; then
 		COUNT=$(wc -l <<<"${FAILED}")
 		echo -e "Failed Units: \033[31m${COUNT}\033[39m"


### PR DESCRIPTION
The output of "systemctl list-units --state=failed --no-legend" still
contains the bullet point which is not expected and ends up being taken
as the unit name which was previously on the start of the line.
Filter the bullet point out to stay compatible with the old behavior in
case upstream would remove the bullet point again.


# How to use

Log in to a system with a failed unit and see that now the unit name is printed while before it was just

```
Failed Units: 1
  ●
```

# Testing done

I manually ran the fixed version of the profile script to see that they now print the unit name as before

```
$ source fixed-flatcar-profile.sh 
Failed Units: 1
  tcsd.service
```
