### PR TITLE
pam.d: enable pam_faillock as replacement for pam_tally2

### DIFF
--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -1,11 +1,14 @@
 auth		required	pam_env.so
+auth		requisite	pam_faillock.so preauth
 auth		sufficient	pam_unix.so try_first_pass likeauth nullok
+auth		[default=die]	pam_faillock.so authfail
 auth		sufficient	pam_sss.so use_first_pass
 auth		required	pam_deny.so
 
 account		required	pam_unix.so
 # Don't fail if the user is unknown to sssd or if sssd isn't running
 account		required	pam_sss.so ignore_unknown_user ignore_authinfo_unavail
+account		required	pam_faillock.so
 account		optional	pam_permit.so
 
 password	sufficient	pam_unix.so try_first_pass nullok sha512 shadow minlen=8

--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -1,7 +1,7 @@
 auth		required	pam_env.so
-auth		requisite	pam_faillock.so preauth
+auth		requisite	pam_faillock.so preauth deny=5 unlock_time=60 fail_interval=120
 auth		sufficient	pam_unix.so try_first_pass likeauth nullok
-auth		[default=die]	pam_faillock.so authfail
+auth		[default=die]	pam_faillock.so authfail deny=5 unlock_time=60 fail_interval=120
 auth		sufficient	pam_sss.so use_first_pass
 auth		required	pam_deny.so
 


### PR DESCRIPTION
In the PAM 1.5 update the deprecated pam_tally2 module had to be
removed. Since pam_faillock should be used as a replacement and it's
included in the image already, set it up by default.
The "faillock" command will show the current state and the password
login prompt is replaced with a message that the account is locked
for X minutes. This only applies to local password login.

With tally there was no limit for wrong password login attempts.
Yes with faillock the default is restricted to three attempts within
15 minutes which lead to a 10 minute account locking. This can be
disturbing for the real user and we can reduce the impact by choosing
a shorter lock duration of one minute and allow up to 5 wrong
passwords per two minutes (i.e., spread over 15 minutes this means
around 35 wrong attempts are possible).

# How to use/testing done

Copy the file to `/etc/pam.d/system-auth` for testing.
Create a test user and set a password: `useradd test; passwd test`.
Now log in via SSH with a wrong password and get locked for some time.
