### PR TITLE
profile: Fix the legend for failed systemd units

### DIFF
--- a/baselayout/flatcar-profile.sh
+++ b/baselayout/flatcar-profile.sh
@@ -32,7 +32,7 @@ if [[ $- == *i* ]]; then
 		)
 	fi
 
-	FAILED=$(systemctl list-units --state=failed --no-legend | tr '●' ' ')
+	FAILED=$(systemctl list-units --state=failed --no-legend | tr '●×' ' ')
 	if [[ ! -z "${FAILED}" ]]; then
 		COUNT=$(wc -l <<<"${FAILED}")
 		echo -e "Failed Units: \033[31m${COUNT}\033[39m"


### PR DESCRIPTION
systemd v249 changes the usual failed units "●" to show "×".
This commit adapts accordingly to display the correct failed units.

-- 
To be merged with https://github.com/flatcar-linux/coreos-overlay/pull/1268
Also, the ref needs to be updated in coreos-overlay once merged
