### PR TITLE
baselayout/group: Add sgx group

### DIFF
--- a/baselayout/group
+++ b/baselayout/group
@@ -44,6 +44,7 @@ systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
 tss:x:252:
+sgx:x:405:
 utmp:x:406:
 core:x:500:
 nogroup:x:65533:


### PR DESCRIPTION
Systemd during the initrd stage was complaining about the missing
group, which resulted in ignoring some of the udev rules. Let's
placate it by adding sgx to baselayout, so the group is available
during the initrd stage too.

The group id was taken from [acct-group/sgx in portage-stable](https://github.com/flatcar-linux/portage-stable/blob/main/acct-group/sgx/sgx-0.ebuild#L8).

Tested locally.