### PR TITLE
baselayout/{passwd,group}: Add missing entries

### DIFF
--- a/baselayout/WARNING
+++ b/baselayout/WARNING
@@ -1,0 +1,4 @@
+systemd-coredump, system-timesync and systemd-oom were dynamically
+allocated for some time, so there users/groups were possibly allocated
+IDs 997, 998 and 999. So when adding new users and groups, let's stay
+away from this range of IDs.

--- a/baselayout/group
+++ b/baselayout/group
@@ -26,6 +26,10 @@ cdrw:x:80:
 usb:x:85:
 users:x:100:
 sudo:x:150:
+netperf:x:168:
+systemd-coredump:x:194:
+systemd-timesync:x:195:
+systemd-oom:x:198:
 messagebus:x:201:
 syslog:x:202:
 ntp:x:203:
@@ -44,6 +48,7 @@ systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
 tss:x:252:
+dnsmasq:x:275:
 sgx:x:405:
 utmp:x:406:
 core:x:500:

--- a/baselayout/passwd
+++ b/baselayout/passwd
@@ -10,6 +10,10 @@ news:x:9:13:news:/var/spool/news:/sbin/nologin
 uucp:x:10:14:uucp:/var/spool/uucp:/sbin/nologin
 operator:x:11:0:operator:/root:/sbin/nologin
 man:x:13:15:man:/usr/share/man:/sbin/nologin
+netperf:x:168:168:netperf:/dev/null:/sbin/nologin
+systemd-coredump:x:194:194:systemd-coredump:/dev-null:/sbin/nologin
+systemd-timesync:x:195:195:systemd-timesync:/dev-null:/sbin/nologin
+systemd-oom:x:198:198:systemd-oom:/dev-null:/sbin/nologin
 messagebus:x:201:201:dbus:/dev/null:/sbin/nologin
 syslog:x:202:202:syslog:/dev/null:/sbin/nologin
 ntp:x:203:203:ntpd:/dev/null:/sbin/nologin
@@ -26,5 +30,6 @@ systemd-network:x:244:244:Network Management Service:/dev/null:/sbin/nologin
 systemd-resolve:x:245:245:Network Name Resolution:/dev/null:/sbin/nologin
 systemd-bus-proxy:x:246:246:Legacy D-Bus Proxy:/dev/null:/sbin/nologin
 portage:x:250:250:portage:/var/tmp/portage:/sbin/nologin
+dnsmasq:x:275:275:dnsmasq:/dev/null:/sbin/nologin
 core:x:500:500:Flatcar Admin:/home/core:/bin/bash
 nobody:x:65534:65534:nobody:/var/empty:/sbin/nologin


### PR DESCRIPTION
Updated netperf needs netperf user and group. Updated systemd needs
various systemd users and groups. Dnsmasq also seems to require its
own user/group.

All this is added to prevent systemd-sysusers adding these to
/etc/passwd. And systemd-sysusers adds these, because the updated
user/group eclass in portage-stable now drops configuration files into
/usr/lib/sysusers.d. Maybe at some point we will switch over to
(patched?) systemd-sysusers, so this catch-up game won't be necessary,
but we are not there yet.
