### PR TITLE
systemd: move files to init repo as unified location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 DESTDIR =
 ETC_DIRS = env.d
-LIB_DIRS = modprobe.d pam.d sysctl.d tmpfiles.d systemd
+LIB_DIRS = modprobe.d pam.d sysctl.d tmpfiles.d
 SHARE_DIRS = baselayout vim
 
 all: baselayout/shadow baselayout/gshadow

--- a/systemd/resolved.conf.d/10-disable-dnssec.conf
+++ b/systemd/resolved.conf.d/10-disable-dnssec.conf
@@ -1,2 +1,0 @@
-[Resolve]
-DNSSEC=false

--- a/systemd/resolved.conf.d/10-disable-llmnr.conf
+++ b/systemd/resolved.conf.d/10-disable-llmnr.conf
@@ -1,3 +1,0 @@
-[Resolve]
-LLMNR=false
-


### PR DESCRIPTION
The systemd drop-in files should only be in one repository, and using
init is better than baselayout for that (baselayout is also used for
the SDK).

## How to use

Together with the init repo PR

## Testing done

See coreos-overlay PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in coreos-overlay