### PR TITLE
baselayout/passwd|group: remove duplicates of acct-user|group

### DIFF
--- a/baselayout/WARNING
+++ b/baselayout/WARNING
@@ -1,6 +1,6 @@
 To ensure stable user ID allocations, the acct-user|group sysuser files
 are used. In case a package uses its own sysuser file with a dynamic
-allocation, we should add it's allocated entry from
+allocation, we should add its allocated entry from
 /usr/share/baselayout/passwd|group here to ensure that the ID is
 stable.
 

--- a/baselayout/WARNING
+++ b/baselayout/WARNING
@@ -1,3 +1,9 @@
+To ensure stable user ID allocations, the acct-user|group sysuser files
+are used. In case a package uses its own sysuser file with a dynamic
+allocation, we should add it's allocated entry from
+/usr/share/baselayout/passwd|group here to ensure that the ID is
+stable.
+
 systemd-coredump, system-timesync and systemd-oom were dynamically
 allocated for some time, so there users/groups were possibly allocated
 IDs 997, 998 and 999. So when adding new users and groups, let's stay

--- a/baselayout/group
+++ b/baselayout/group
@@ -27,9 +27,6 @@ usb:x:85:
 users:x:100:
 sudo:x:150:
 netperf:x:168:
-systemd-coredump:x:194:
-systemd-timesync:x:195:
-systemd-oom:x:198:
 messagebus:x:201:
 syslog:x:202:
 ntp:x:203:
@@ -48,7 +45,6 @@ systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
 tss:x:252:
-dnsmasq:x:275:
 sgx:x:405:
 utmp:x:406:
 core:x:500:

--- a/baselayout/passwd
+++ b/baselayout/passwd
@@ -11,9 +11,6 @@ uucp:x:10:14:uucp:/var/spool/uucp:/sbin/nologin
 operator:x:11:0:operator:/root:/sbin/nologin
 man:x:13:15:man:/usr/share/man:/sbin/nologin
 netperf:x:168:168:netperf:/dev/null:/sbin/nologin
-systemd-coredump:x:194:194:systemd-coredump:/dev-null:/sbin/nologin
-systemd-timesync:x:195:195:systemd-timesync:/dev-null:/sbin/nologin
-systemd-oom:x:198:198:systemd-oom:/dev-null:/sbin/nologin
 messagebus:x:201:201:dbus:/dev/null:/sbin/nologin
 syslog:x:202:202:syslog:/dev/null:/sbin/nologin
 ntp:x:203:203:ntpd:/dev/null:/sbin/nologin
@@ -30,6 +27,5 @@ systemd-network:x:244:244:Network Management Service:/dev/null:/sbin/nologin
 systemd-resolve:x:245:245:Network Name Resolution:/dev/null:/sbin/nologin
 systemd-bus-proxy:x:246:246:Legacy D-Bus Proxy:/dev/null:/sbin/nologin
 portage:x:250:250:portage:/var/tmp/portage:/sbin/nologin
-dnsmasq:x:275:275:dnsmasq:/dev/null:/sbin/nologin
 core:x:500:500:Flatcar Admin:/home/core:/bin/bash
 nobody:x:65534:65534:nobody:/var/empty:/sbin/nologin


### PR DESCRIPTION
Unfortunately we diverge with some IDs from Gentoo's acct-user and
acct-group allocations but for some not and we can rely on Gentoo's
sysuser config files to create them.

## How to use

Test case for scripts PR https://github.com/flatcar-linux/scripts/pull/227

## Testing done

see https://github.com/flatcar-linux/scripts/pull/227
