### PR TITLE
tmpfiles.d: add relabel option

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -14,3 +14,4 @@ L   /etc/vim/vimrc                    -   -   -   -   ../../usr/share/vim/vimrc
 d   /etc/sudoers.d                    0750    root    root    -   -
 d   /etc/flatcar                      -   -   -   -   -
 L   /etc/coreos                       -   -   -   -   ./flatcar
+Z   /etc                              -   -   -   -   -


### PR DESCRIPTION
these three files appears with `unlabeled_t` label. They are not created
directly by systemd-tmpfiles but elsewhere (like flatcar-tmpfiles)

It creates a bunch of AVC like:
```
Jul 07 08:22:12 localhost audit[722]: AVC avc:  denied  { open } for  pid=722 comm="flatcar-autolog" path="/etc/passwd" dev="vda9" ino=22 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
```

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Manually fix the labels, it seems to do the trick and `systemd-tmpfiles` seems to run _after_ `flatcar-tmpfiles`.