### PR TITLE
tmpfiles.d/baselayout-etc.conf: Only relabel a minimal set of files

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -14,4 +14,7 @@ L   /etc/vim/vimrc                    -   -   -   -   ../../usr/share/vim/vimrc
 d   /etc/sudoers.d                    0750    root    root    -   -
 d   /etc/flatcar                      -   -   -   -   -
 L   /etc/coreos                       -   -   -   -   ./flatcar
-Z   /etc                              -   -   -   -   -
+Z   /etc/passwd                       -   -   -   -   -
+Z   /etc/shadow                       -   -   -   -   -
+Z   /etc/group                        -   -   -   -   -
+Z   /etc/gshadow                      -   -   -   -   -


### PR DESCRIPTION
For now, the systemd-tmpfiles Z rule for SELinux relabeling seems to cause unnecessary upcopies in the /etc overlay.
Restrict the set of files we relabel to the ones created unlabeled by flatcar-tmpfiles.

## How to use

Bugfix for https://github.com/flatcar/baselayout/pull/24 hopefully before branching the new Alpha

## Testing done

Manual test with
```
sudo unshare -m
umount /etc
rm -rf /etc/*
mkdir /etc/tmpfiles.d
cat > /etc/tmpfiles.d/baselayout-etc.conf  # and pasting the below (end with ctrl D)
d   /etc                              -   -   -   -   -
Z   /etc/passwd                       -   -   -   -   -
Z   /etc/shadow                       -   -   -   -   -
Z   /etc/group                        -   -   -   -   -
Z   /etc/gshadow                      -   -   -   -   -
```

Then I rebooted and the upcopies were not coming back and files like `/etc/passwd` got labeled with `system_u:object_r:etc_t:s0`

[CI started](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/691/cldsv/)