### PR TITLE
tmpfiles.d: Add /var/log as entry for baselayout.conf

### DIFF
--- a/scripts/flatcar-tmpfiles
+++ b/scripts/flatcar-tmpfiles
@@ -8,9 +8,9 @@
 ROOT="${1:-$ROOT}"
 BASE="${2:-${ROOT}/usr/share/baselayout}"
 
-# Users/Groups to copy so they can be modified
+# Users/Groups to copy so they can be modified (systemd-journal is also needed for systemd-tmpfiles)
 COPY_USERS="root|core"
-COPY_GROUPS="root|core|docker|sudo|wheel"
+COPY_GROUPS="root|core|docker|sudo|wheel|systemd-journal"
 
 mkdir -p "${ROOT}/etc"
 

--- a/tmpfiles.d/baselayout.conf
+++ b/tmpfiles.d/baselayout.conf
@@ -13,3 +13,8 @@ d   /var        0755    -   -   -   -
 d   /var/empty  -       -   -   -   -
 L   /var/lock   -       -   -   -   ../run/lock
 L   /var/run    -       -   -   -   ../run
+# Explicitly add /var/log here even if it has a duplicate in var.conf
+# but for the initrd we don't apply var.conf
+d   /var/log    0755    -   -   -   -
+# Same for /var/log/journal, but without "z" as the relabeling will be done later
+d /var/log/journal 2755 root systemd-journal - -


### PR DESCRIPTION
The persisting of logs on first boot didn't work anymore because /var/log wasn't created early enough as Mathieu found out. The /var/log directory is set up by var.conf from systemd which we can't easily apply from the initrd due to the utmp user defined there. As workaround, add /var/log also to baselayout.conf which gets applied  
from the initrd - but even here we have to copy the systemd-journal     
group over to /sysroot/etc/group because systemd-tmpfiles only looks    
there and doesn't load the libc and its nss plugin from the chroot.     

## How to use

Backport to Alpha

## Testing done
see https://github.com/flatcar/bootengine/pull/60
