### PR TITLE
tmpfiles.d: Drop creation of core user bash symlinks

### DIFF
--- a/tmpfiles.d/baselayout-home.conf
+++ b/tmpfiles.d/baselayout-home.conf
@@ -1,5 +1,2 @@
 d /home/core            0755    core    core    -   -
 d /home/core/.ssh       0700    core    core    -   -
-L /home/core/.bash_logout   -   core    core    -   ../../usr/share/skel/.bash_logout
-L /home/core/.bash_profile  -   core    core    -   ../../usr/share/skel/.bash_profile
-L /home/core/.bashrc        -   core    core    -   ../../usr/share/skel/.bashrc


### PR DESCRIPTION
These will be created by a config file installed by the coreos-base/misc-files package, which will make sure that the symlinks will use new locations for those bash files and they won't dangle.

Tested as a part of https://github.com/flatcar/scripts/pull/776

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/796/cldsv/