### PR TITLE
group, passwd: fix messagebus user/group

### DIFF
--- a/share/baselayout/group
+++ b/share/baselayout/group
@@ -27,7 +27,7 @@ usb:x:85:
 users:x:100:
 sudo:x:150:
 netperf:x:168:
-messagebus:x:201:
+messagebus:x:101:
 syslog:x:202:
 ntp:x:203:
 sshd:x:204:

--- a/share/baselayout/passwd
+++ b/share/baselayout/passwd
@@ -11,7 +11,7 @@ uucp:x:10:14:uucp:/var/spool/uucp:/sbin/nologin
 operator:x:11:0:operator:/root:/sbin/nologin
 man:x:13:15:man:/usr/share/man:/sbin/nologin
 netperf:x:168:168:netperf:/dev/null:/sbin/nologin
-messagebus:x:201:201:dbus:/dev/null:/sbin/nologin
+messagebus:x:101:101:dbus:/dev/null:/sbin/nologin
 syslog:x:202:202:syslog:/dev/null:/sbin/nologin
 ntp:x:203:203:ntpd:/dev/null:/sbin/nologin
 sshd:x:204:204:openssh:/var/empty:/sbin/nologin


### PR DESCRIPTION
In the scripts repo's portage-stable/acct-(user|group)/. messagebus has [uid 101](https://github.com/flatcar/scripts/blob/main/sdk_container/src/third_party/portage-stable/acct-user/messagebus/messagebus-0-r3.ebuild) and [gid 101.](https://github.com/flatcar/scripts/blob/main/sdk_container/src/third_party/portage-stable/acct-group/messagebus/messagebus-0-r3.ebuild)

In our baselayout's /etc/passwd and /etc/group messagebus' UID / GID are 201/201.
Consequently, information about UID 101 / GID 101 is missing from live Flatcar systems and items with this ownership are displayed as being owned by "UNKNOWN".

This change updates baselayout to also use 101.

# Testing done

Tested in conjunction with https://github.com/flatcar/scripts/pull/3132

**Before the change**
```sh
core@localhost ~ $ ls -la /usr/libexec/dbus-daemon-launch-helper
---s--x---. 1 root 101 65096 Jun 20 21:20 /usr/libexec/dbus-daemon-launch-helper
core@localhost ~ $ stat /usr/libexec/dbus-daemon-launch-helper
  File: /usr/libexec/dbus-daemon-launch-helper
  Size: 65096           Blocks: 128        IO Block: 4096   regular file
Device: 0,58    Inode: 30262       Links: 1
Access: (4110/---s--x---)  Uid: (    0/    root)   Gid: (  101/ UNKNOWN)
[...]
```

**After the change**
```sh
core@localhost ~ $ ls -la /usr/libexec/dbus-daemon-launch-helper
---s--x---. 1 root messagebus 65096 Jul 15 02:20 /usr/libexec/dbus-daemon-launch-helper
core@localhost ~ # stat /usr/libexec/dbus-daemon-launch-helper
  File: /usr/libexec/dbus-daemon-launch-helper
  Size: 65096           Blocks: 128        IO Block: 4096   regular file
Device: 0,58    Inode: 30298       Links: 1
Access: (4110/---s--x---)  Uid: (    0/    root)   Gid: (  101/messagebus)
```