### PR TITLE
flatcar-tmpfiles: Copy over the shadow group and use it for shadow files

### DIFF
--- a/bin/flatcar-tmpfiles
+++ b/bin/flatcar-tmpfiles
@@ -15,24 +15,44 @@ COPY_GROUPS="root|core|docker|sudo|wheel|systemd-journal|shadow"
 
 mkdir -p "${ROOT}/etc"
 
+# Output those lines in BASE/passwd (that are to be copied) when their
+# user names are not in /etc/passwd already, and append the entries
+# from BASE/passwd to /etc/passwd. We are fine if /etc/passwd doesn't
+# exist as this will result in no patterns. As patterns have the
+# filtering out function, no patterns means that every line will
+# match.
+function copy_from_base_to_etc {
+    local file=${1}; shift # passwd, group, shadow, gshadow
+    local copy_re=${1}; shift # either ${COPY_GROUPS} or ${COPY_USERS}
+
+    local root_file="${ROOT}/etc/${file}" base_file="${BASE}/${file}" pattern_file=/dev/null tmp_file=''
+
+    if [[ -e ${root_file} ]]; then
+        # It may fail if with /tmp.
+        tmp_file=$(mktemp --tmpdir="${ROOT}/etc")
+        cut --only-delimited --delimiter=":" --fields=1 "${root_file}" | \
+            sed -e 's/$/:.*/' >"${tmp_file}"
+        if [[ -s ${tmp_file} ]]; then
+            pattern_file=${tmp_file}
+        fi
+    fi
+    grep \
+        --invert-match \
+        --line-regexp \
+        --file "${pattern_file}" \
+        <(grep --extended-regexp --regexp="^(${copy_re}):" "${base_file}") >>"${root_file}"
+    if [[ -n ${tmp_file} ]]; then rm -f "${tmp_file}"; fi
+}
+
 # readable files
 umask 022
-# Output those lines in BASE/passwd (that are to be copied) when their user/group names are not in /etc/passwd already,
-# and append the entries from BASE/passwd to /etc/passwd.
-# But since we don't want lines/half lines being added also be used as patterns, we first read the file and in a second
-# step write to it. (We are fine if /etc/passwd doesn't exist as this will result in no patterns. As patterns have the
-# filtering out function, no patterns means that every line will match.)
-PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/passwd" | sed 's/^/\^/' | sed 's/$/:.*$/')
-grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_USERS}):" "${BASE}/passwd") >> "${ROOT}/etc/passwd"
-PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/group" | sed 's/^/\^/' | sed 's/$/:.*$/')
-grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_GROUPS}):" "${BASE}/group") >> "${ROOT}/etc/group"
+copy_from_base_to_etc passwd "${COPY_USERS}"
+copy_from_base_to_etc group "${COPY_GROUPS}"
 
 # secure files
 umask 027
-PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/shadow" | sed 's/^/\^/' | sed 's/$/:.*$/')
-grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_USERS}):" "${BASE}/shadow") >> "${ROOT}/etc/shadow"
-PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/gshadow" | sed 's/^/\^/' | sed 's/$/:.*$/')
-grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_GROUPS}):" "${BASE}/gshadow") >> "${ROOT}/etc/gshadow"
+copy_from_base_to_etc shadow "${COPY_USERS}"
+copy_from_base_to_etc gshadow "${COPY_GROUPS}"
 
 SHADOW_GID=$(grep '^shadow:' "${ROOT}/etc/group" | cut -d: -f3)
 chown ":${SHADOW_GID}" "${ROOT}"/etc/{g,}shadow || exit 1

--- a/bin/flatcar-tmpfiles
+++ b/bin/flatcar-tmpfiles
@@ -3,6 +3,7 @@
 # - copy the docker group to /etc because docker reads /etc/group directly
 # - copy the sudo and wheel groups to /etc so that new uses can be added to them
 # - copy the core and root users to /etc so the passwd utility works correctly
+# - copy the shadow group to /etc so the shadow and gshadow files can be owned by the group
 
 # Inherit root from environment or command line
 ROOT="${1:-$ROOT}"
@@ -10,7 +11,7 @@ BASE="${2:-${ROOT}/usr/share/baselayout}"
 
 # Users/Groups to copy so they can be modified (systemd-journal is also needed for systemd-tmpfiles)
 COPY_USERS="root|core"
-COPY_GROUPS="root|core|docker|sudo|wheel|systemd-journal"
+COPY_GROUPS="root|core|docker|sudo|wheel|systemd-journal|shadow"
 
 mkdir -p "${ROOT}/etc"
 
@@ -32,6 +33,9 @@ PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/shadow" | sed 's/^/\^/' | sed 's/$/:.
 grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_USERS}):" "${BASE}/shadow") >> "${ROOT}/etc/shadow"
 PATTERNS=$(cut -s -d ":" -f 1 "${ROOT}/etc/gshadow" | sed 's/^/\^/' | sed 's/$/:.*$/')
 grep -v -x -f <(echo "${PATTERNS}") <(grep -E -e "^(${COPY_GROUPS}):" "${BASE}/gshadow") >> "${ROOT}/etc/gshadow"
+
+SHADOW_GID=$(grep '^shadow:' "${ROOT}/etc/group" | cut -d: -f3)
+chown ":${SHADOW_GID}" "${ROOT}"/etc/{g,}shadow || exit 1
 
 # The script runs without set -euo pipefail and allows grep to return 1, thus the last statement must not be grep
 # because it would propagate the exit code 1 and let the systemd unit fail.


### PR DESCRIPTION
Some binaries acting on those files are now owned by the shadow group
with a sticky bit instead of having CAP_DAC_SEARCH (or
CAP_DAC_OVERRIDE) caps. For them to work, shadow and gshadow files
also need to be owned by the group shadow.

Will be tested together with the weekly updates.