### PR TITLE
Makefile: Drop /usr/lib/debug directories and symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,9 @@ install:
 	# backwards compatibility for /etc/motd
 	ln -snf /run/flatcar/motd $(DESTDIR)/usr/share/baselayout/motd
 
-ALL_DIRS = $(foreach dir, bin local/bin local/sbin $(foreach dir2, $(LIBDIRS), $(dir2) local/$(dir2)),usr/$(dir) usr/lib/debug/usr/$(dir))
+ALL_DIRS = $(foreach dir, bin local/bin local/sbin $(foreach dir2, $(LIBDIRS), $(dir2) local/$(dir2)),usr/$(dir))
 # target:linkname pairs
-ALL_LINKS = \
-	$(foreach dir, bin $(LIBDIRS),usr/$(dir):$(dir) usr/$(dir):usr/lib/debug/$(dir)) \
-	usr/bin:sbin usr/bin:usr/lib/debug/sbin bin:usr/sbin bin:usr/lib/debug/usr/sbin
+ALL_LINKS = $(foreach dir, bin $(LIBDIRS),usr/$(dir):$(dir)) usr/bin:sbin bin:usr/sbin
 
 layout:
 	for d in $(ALL_DIRS); do \


### PR DESCRIPTION
# Makefile: Drop /usr/lib/debug directories and symlinks

Gentoo starts with this directory being empty, and Portage complains if you populate it with merge-usr symlinks. See flatcar/scripts#3870 for the wider context.

## How to use

After building, there should be no directory symlinks.

## Testing done

A [Jenkins SDK build](https://jenkins.flatcar.org/job/container/job/sdk/10/cldsv/) with the wider *scripts* changes passed. We cannot currently run the arm64 tests.