### PR TITLE
lib/tmpfiles.d: symlink networks, protocols, rpc and services into /etc

### DIFF
--- a/lib/tmpfiles.d/baselayout-etc.conf
+++ b/lib/tmpfiles.d/baselayout-etc.conf
@@ -2,6 +2,10 @@ d   /etc                              -   -   -   -   -
 L   /etc/inputrc                      -   -   -   -   ../usr/share/baselayout/inputrc
 L   /etc/motd                         -   -   -   -   ../run/flatcar/motd
 L   /etc/nsswitch.conf                -   -   -   -   ../usr/share/baselayout/nsswitch.conf
+L   /etc/networks                     -   -   -   -   ../usr/share/baselayout/networks
+L   /etc/protocols                    -   -   -   -   ../usr/share/baselayout/protocols
+L   /etc/rpc                          -   -   -   -   ../usr/share/baselayout/rpc
+L   /etc/services                     -   -   -   -   ../usr/share/baselayout/services
 L   /etc/lsb-release                  -   -   -   -   ../usr/share/flatcar/lsb-release
 L   /etc/profile                      -   -   -   -   ../usr/share/baselayout/profile
 d   /etc/profile.d                    0755    root    root    -   -


### PR DESCRIPTION
`/etc/protocols`, `/etc/services`, `/etc/rpc` and `/etc/networks` are not on disk in flatcar. Glibc finds them under `/usr/share/baselayout/` through the `usrfiles` NSS module wired up in `nsswitch.conf`, so `getprotobyname()` and friends work fine and nothing looks broken.

Anything that opens those paths directly does break though. Statically linked binaries and go programs parse `/etc/protocols` themselves, and kubernetes workloads that mount the file as a `hostPath` with `type: File` do not even start, because kubelet requires the path to exist on the host, this is what [azure-npm](https://github.com/Azure/azure-container-networking/blob/969e8e04d7430627776be6210bc3a5cd70eecade/npm/azure-npm.yaml#L126) runs into.

So this PR adds four `L` lines to `baselayout-etc.conf` pointing back at the copies in `/usr/share/baselayout/`, exactly how `/etc/nsswitch.conf` and `/etc/issue` are already handled. `L` leaves an existing path alone, so anyone who put their own file in `/etc` keeps it.

- Fixes flatcar/Flatcar#1852
